### PR TITLE
added loading of seleced paths in timetable when adding folderpair

### DIFF
--- a/WinBackupper/Settings.vb
+++ b/WinBackupper/Settings.vb
@@ -9,9 +9,9 @@ Public Class Settings
     '*----Global Variables----*'
     '*------------------------*'
     Dim defaultsourcePath As String 'set via code - read from settings and set like that.
-    Public sourcepatharray As ArrayList = WinBackupper.home.sourcepatharray 'reference to form1.vb array. (which is loaded first)
+    Public Shared sourcepatharray As ArrayList = WinBackupper.home.sourcepatharray 'reference to form1.vb array. (which is loaded first)
     Dim defaultbackupPath As String 'set via code - read from settings and set like that.
-    Public backupPatharray As ArrayList = WinBackupper.home.backupPatharray 'reference to form1.vb array. (which is loaded first)
+    Public Shared backupPatharray As ArrayList = WinBackupper.home.backupPatharray 'reference to form1.vb array. (which is loaded first)
     Dim tempSourcePath As String
     Dim tempBackupPath As String
     Dim GlobalSeperator As String = WinBackupper.home.GlobalSeperator ' seperatir used to combine/cut strings (like allsourcepaths)

--- a/WinBackupper/Timetable.vb
+++ b/WinBackupper/Timetable.vb
@@ -913,7 +913,23 @@ Public Class Timetable
                 'select index 0 again (monday = 0) / or current day?
                 dd_Day.SelectedIndex = 0
             Else
-                'is nothing - dont  load settings => a new entry is created)
+                'is nothing => a new entry is created)
+
+                'If a new entry is added, load the path settings from the last choice 
+                'the user then has a chance to correct them etc... 
+
+                'get values from array - they are in there but no line is selected
+                'but they are the last members, since they just got added => grab them
+                'count how many items are in the listview - that number is the index of the new item,
+                '(Count is human value and begins with 1- array begins with 0 so the number of items is the index of the new file (same logic already used before)
+
+                Dim sourcepath As String = Settings.sourcepatharray(Settings.lv_settings.Items.Count - 1)
+                Dim backuppath As String = Settings.backupPatharray(Settings.lv_settings.Items.Count - 1)
+
+                'then write them into they textboxes
+                tb_showSource.Text = sourcepath
+                tb_showBackup.Text = backuppath
+
             End If
         Catch ex As Exception
             MessageBox.Show(ex.Message & vbNewLine & "Above Error occured in Settings_Reload Function", "Error occured!", MessageBoxButtons.OK, MessageBoxIcon.Error)


### PR DESCRIPTION
added loading of seleced paths in timetable when adding folderpair
When you add a folderpair now, the timetable form shows the selected
directories so the user can check/correct them if needed.
