### PR TITLE
Polishing for Release

### DIFF
--- a/WinBackupper/My Project/AssemblyInfo.vb
+++ b/WinBackupper/My Project/AssemblyInfo.vb
@@ -18,7 +18,7 @@ Imports System.Runtime.InteropServices
 <Assembly: ComVisible(False)> 
 
 'The following GUID is for the ID of the typelib if this project is exposed to COM
-<Assembly: Guid("571cce82-572f-41f5-8b2e-cca2adaa0605")> 
+<Assembly: Guid("571cce82-572f-41f5-8b2e-cca2adaa0605")>
 
 ' Version information for an assembly consists of the following four values:
 '
@@ -31,5 +31,5 @@ Imports System.Runtime.InteropServices
 ' by using the '*' as shown below:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("0.0.0.12")> 
-<Assembly: AssemblyFileVersion("0.0.0.12")> 
+<Assembly: AssemblyVersion("0.0.1.0")>
+<Assembly: AssemblyFileVersion("0.0.1.0")>

--- a/WinBackupper/Settings.vb
+++ b/WinBackupper/Settings.vb
@@ -244,9 +244,9 @@ Public Class Settings
     'Button Save defaults to own XML File
     Private Sub b_save_Click(sender As Object, e As EventArgs) Handles b_save.Click
         'delete default.xml if it exists already
-        If System.IO.File.Exists(home.getexedir() & "\default.xml") Then
+        If System.IO.File.Exists(home.getexedir() & home.Settings_Directory & "default.xml") Then
             'delete it 
-            System.IO.File.Delete(home.getexedir() & "\default.xml")
+            System.IO.File.Delete(home.getexedir() & home.Settings_Directory & "default.xml")
         End If
         'start bw_writer which writes default.xml in backgournd (other thread)
         bw_writer.RunWorkerAsync()
@@ -262,9 +262,9 @@ Public Class Settings
 
         If resetchoice = vbYes Then
             'delete xml file - reset arrays
-            If System.IO.File.Exists(home.getexedir() & "\default.xml") Then
+            If System.IO.File.Exists(home.getexedir() & home.Settings_Directory & "default.xml") Then
                 'delete it 
-                System.IO.File.Delete(home.getexedir() & "\default.xml")
+                System.IO.File.Delete(home.getexedir() & home.Settings_Directory & "default.xml")
             End If
             'Clear Array
             sourcepatharray.Clear()
@@ -339,6 +339,14 @@ Public Class Settings
                 'add it anyway, even if already existing in source list
                 'write value into Array!
                 sourcepatharray.Add(SourcePathresult)
+            Else
+                MessageBox.Show("Adding of Folderpair aborted!")
+                If DialogResult = Windows.Forms.DialogResult.OK Then
+                    'this is a workaround for a weird behavior when calling forms as dialog (and other dialogs)
+                    'see further down
+                    DialogResult = DialogResult.None
+                End If
+                Exit Sub
             End If
         Else
             'sane string ...add it
@@ -351,17 +359,26 @@ Public Class Settings
         fbd_searchDefaultBackup.RootFolder = Environment.SpecialFolder.MyComputer
         DialogResult = fbd_searchDefaultBackup.ShowDialog
         Dim BackupPathresult As String = fbd_searchDefaultBackup.SelectedPath.ToString
-        'do sanity check before adding (check if already existing?)
         If Not DialogResult = Windows.Forms.DialogResult.OK Then ' makes sure the user clicked on "ok" if not it exists the function
             MessageBox.Show("Adding of Folderpair aborted!")
             Exit Sub
         End If
+        'do sanity check before adding (check if already existing?)
         If sourcepatharray.Contains(BackupPathresult) And DialogResult = Windows.Forms.DialogResult.OK Then ' makes sure the user clicked on "ok"
             Dim userchoice = MessageBox.Show("You want to save into a Folder which is getting back-upped itself" & vbNewLine & "Do you want to continue?", "Destination getting Backupped!", MessageBoxButtons.YesNo, MessageBoxIcon.Question)
-            If userchoice = vbYes Then
-                'add it anyway, even if user is saving data into a directory which is getting backed-up
+            If userchoice = vbYes Then                'add it anyway, even if user is saving data into a directory which is getting backed-up
                 'write value into Array!
                 backupPatharray.Add(BackupPathresult)
+            Else
+                MessageBox.Show("Adding of Folderpair aborted!")
+                'if aborted here - the source path s already in the array - so celan up
+                sourcepatharray.RemoveAt(sourcepatharray.Count - 1)
+                If DialogResult = Windows.Forms.DialogResult.OK Then
+                    'this is a workaround for a weird behavior when calling forms as dialog (and other dialogs)
+                    'see further down
+                    DialogResult = DialogResult.None
+                End If
+                Exit Sub
             End If
         Else
             'sane string ...add it
@@ -436,7 +453,7 @@ Public Class Settings
         ' Create XML Writer
         Dim writerOption As New XmlWriterSettings
         writerOption.Indent = True
-        Dim writerSettings As XmlWriter = XmlWriter.Create(home.getexedir() & "\default.xml", writerOption)
+        Dim writerSettings As XmlWriter = XmlWriter.Create(home.getexedir() & home.Settings_Directory & "default.xml", writerOption)
         'check if array's have unequal nr of members
         'maybe user closed box to choose backup path or didnt open it 
         If Not (sourcepatharray.Count = backupPatharray.Count) Then
@@ -497,9 +514,9 @@ Public Class Settings
 
 
         'start checking if settings are saved correctly!
-        If Not Dir(home.getexedir() & "\default.xml") = "" Then
+        If Not Dir(home.getexedir() & home.Settings_Directory & "default.xml") = "" Then
             ' Read XML File to check if it was written
-            Dim xmlReader As XmlReader = New XmlTextReader(home.getexedir() & "\default.xml")
+            Dim xmlReader As XmlReader = New XmlTextReader(home.getexedir() & home.Settings_Directory & "default.xml")
             'define var's used to compare saveddata to supposed data
             Dim sourcetargetdata As ArrayList = sourcepatharray
             Dim backuptargetdata As ArrayList = backupPatharray

--- a/WinBackupper/Timetable.Designer.vb
+++ b/WinBackupper/Timetable.Designer.vb
@@ -1,9 +1,9 @@
-﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()>
 Partial Class Timetable
     Inherits System.Windows.Forms.Form
 
     'Form overrides dispose to clean up the component list.
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Protected Overrides Sub Dispose(ByVal disposing As Boolean)
         Try
             If disposing AndAlso components IsNot Nothing Then
@@ -20,7 +20,7 @@ Partial Class Timetable
     'NOTE: The following procedure is required by the Windows Form Designer
     'It can be modified using the Windows Form Designer.  
     'Do not modify it using the code editor.
-    <System.Diagnostics.DebuggerStepThrough()> _
+    <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(Timetable))
         Me.b_stopediting = New System.Windows.Forms.Button()
@@ -49,7 +49,6 @@ Partial Class Timetable
         Me.GroupBox1 = New System.Windows.Forms.GroupBox()
         Me.fbd_editsource = New System.Windows.Forms.FolderBrowserDialog()
         Me.fbd_editbackup = New System.Windows.Forms.FolderBrowserDialog()
-        Me.b_exit = New System.Windows.Forms.Button()
         Me.gb_paths.SuspendLayout()
         Me.GroupBox1.SuspendLayout()
         Me.SuspendLayout()
@@ -80,11 +79,11 @@ Partial Class Timetable
         '
         Me.l_source.AutoSize = True
         Me.l_source.BackColor = System.Drawing.Color.Transparent
-        Me.l_source.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.l_source.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
         Me.l_source.ForeColor = System.Drawing.SystemColors.ButtonFace
         Me.l_source.Location = New System.Drawing.Point(6, 17)
         Me.l_source.Name = "l_source"
-        Me.l_source.Size = New System.Drawing.Size(90, 17)
+        Me.l_source.Size = New System.Drawing.Size(101, 20)
         Me.l_source.TabIndex = 35
         Me.l_source.Text = "Source Path:"
         '
@@ -92,11 +91,11 @@ Partial Class Timetable
         '
         Me.l_backup.AutoSize = True
         Me.l_backup.BackColor = System.Drawing.Color.Transparent
-        Me.l_backup.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.l_backup.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
         Me.l_backup.ForeColor = System.Drawing.SystemColors.ButtonFace
         Me.l_backup.Location = New System.Drawing.Point(6, 46)
         Me.l_backup.Name = "l_backup"
-        Me.l_backup.Size = New System.Drawing.Size(92, 17)
+        Me.l_backup.Size = New System.Drawing.Size(104, 20)
         Me.l_backup.TabIndex = 36
         Me.l_backup.Text = "Backup Path:"
         '
@@ -113,19 +112,19 @@ Partial Class Timetable
         'tb_showSource
         '
         Me.tb_showSource.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        Me.tb_showSource.Location = New System.Drawing.Point(104, 14)
+        Me.tb_showSource.Location = New System.Drawing.Point(116, 14)
         Me.tb_showSource.Name = "tb_showSource"
         Me.tb_showSource.ReadOnly = True
-        Me.tb_showSource.Size = New System.Drawing.Size(239, 23)
+        Me.tb_showSource.Size = New System.Drawing.Size(227, 23)
         Me.tb_showSource.TabIndex = 38
         '
         'tb_showBackup
         '
         Me.tb_showBackup.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        Me.tb_showBackup.Location = New System.Drawing.Point(104, 43)
+        Me.tb_showBackup.Location = New System.Drawing.Point(116, 43)
         Me.tb_showBackup.Name = "tb_showBackup"
         Me.tb_showBackup.ReadOnly = True
-        Me.tb_showBackup.Size = New System.Drawing.Size(239, 23)
+        Me.tb_showBackup.Size = New System.Drawing.Size(227, 23)
         Me.tb_showBackup.TabIndex = 39
         '
         'b_editBackup
@@ -204,11 +203,11 @@ Partial Class Timetable
         '
         Me.Label2.AutoSize = True
         Me.Label2.BackColor = System.Drawing.Color.Transparent
-        Me.Label2.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.Label2.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
         Me.Label2.ForeColor = System.Drawing.SystemColors.ButtonFace
         Me.Label2.Location = New System.Drawing.Point(101, 69)
         Me.Label2.Name = "Label2"
-        Me.Label2.Size = New System.Drawing.Size(98, 17)
+        Me.Label2.Size = New System.Drawing.Size(107, 20)
         Me.Label2.TabIndex = 28
         Me.Label2.Text = "Intervall (in h):"
         '
@@ -236,11 +235,11 @@ Partial Class Timetable
         '
         Me.Label1.AutoSize = True
         Me.Label1.BackColor = System.Drawing.Color.Transparent
-        Me.Label1.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.Label1.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
         Me.Label1.ForeColor = System.Drawing.SystemColors.ButtonFace
         Me.Label1.Location = New System.Drawing.Point(101, 46)
         Me.Label1.Name = "Label1"
-        Me.Label1.Size = New System.Drawing.Size(68, 17)
+        Me.Label1.Size = New System.Drawing.Size(78, 20)
         Me.Label1.TabIndex = 27
         Me.Label1.Text = "Starttime:"
         '
@@ -267,11 +266,11 @@ Partial Class Timetable
         '
         Me.l_sourcePath.AutoSize = True
         Me.l_sourcePath.BackColor = System.Drawing.Color.Transparent
-        Me.l_sourcePath.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.l_sourcePath.Font = New System.Drawing.Font("Microsoft Sans Serif", 12.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
         Me.l_sourcePath.ForeColor = System.Drawing.SystemColors.ButtonFace
         Me.l_sourcePath.Location = New System.Drawing.Point(101, 16)
         Me.l_sourcePath.Name = "l_sourcePath"
-        Me.l_sourcePath.Size = New System.Drawing.Size(37, 17)
+        Me.l_sourcePath.Size = New System.Drawing.Size(41, 20)
         Me.l_sourcePath.TabIndex = 26
         Me.l_sourcePath.Text = "Day:"
         '
@@ -319,23 +318,12 @@ Partial Class Timetable
         'fbd_editbackup
         '
         '
-        'b_exit
-        '
-        Me.b_exit.Font = New System.Drawing.Font("Microsoft Sans Serif", 14.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
-        Me.b_exit.Location = New System.Drawing.Point(116, 625)
-        Me.b_exit.Name = "b_exit"
-        Me.b_exit.Size = New System.Drawing.Size(239, 36)
-        Me.b_exit.TabIndex = 34
-        Me.b_exit.Text = "Finish"
-        Me.b_exit.UseVisualStyleBackColor = True
-        '
         'Timetable
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.BackgroundImage = Global.WinBackupper.My.Resources.Resources.gray_background_3
-        Me.ClientSize = New System.Drawing.Size(454, 673)
-        Me.Controls.Add(Me.b_exit)
+        Me.ClientSize = New System.Drawing.Size(454, 629)
         Me.Controls.Add(Me.GroupBox1)
         Me.Controls.Add(Me.gb_paths)
         Me.Controls.Add(Me.l_settings)
@@ -377,5 +365,4 @@ Partial Class Timetable
     Friend WithEvents GroupBox1 As System.Windows.Forms.GroupBox
     Friend WithEvents fbd_editsource As FolderBrowserDialog
     Friend WithEvents fbd_editbackup As FolderBrowserDialog
-    Friend WithEvents b_exit As Button
 End Class

--- a/WinBackupper/Timetable.resx
+++ b/WinBackupper/Timetable.resx
@@ -123,6 +123,9 @@
   <metadata name="fbd_editbackup.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>149, 17</value>
   </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>51</value>
+  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/WinBackupper/Timetable.vb
+++ b/WinBackupper/Timetable.vb
@@ -737,13 +737,6 @@ Public Class Timetable
             home.timesettingsarray.Add(finalstring)
         End If
 
-        ' MsgBox(lvc_Mon.Count.ToString & " | " & lvc_Tue.Count.ToString & " | " & lvc_Wed.Count.ToString & " | " & lvc_Thu.Count.ToString & " | " & lvc_Fri.Count.ToString & " | " & lvc_Sat.Count.ToString & " | " & lvc_Sun.Count.ToString & " | ")
-
-        'This Button doesn't close the Form any more!
-    End Sub
-
-    'Button to close Form
-    Private Sub b_exit_Click(sender As Object, e As EventArgs) Handles b_exit.Click
         'Exit Form
         Me.Close()
     End Sub
@@ -925,10 +918,8 @@ Public Class Timetable
                 'the user then has a chance to correct them etc... 
 
                 'get values from array - they are in there but no line is selected
-                'but they are the last members, since they just got added => grab them
-                'count how many items are in the listview - that number is the index of the new item,
-                '(Count is human value and begins with 1- array begins with 0 so the number of items is the index of the new file (same logic already used before)
-
+                'the array already has the newly added paths in it,
+                'therefore calculate the index correctly.
                 Dim sourcepath As String = Settings.sourcepatharray(Settings.lv_settings.Items.Count - 1)
                 Dim backuppath As String = Settings.backupPatharray(Settings.lv_settings.Items.Count - 1)
 

--- a/WinBackupper/WinBackupper.vbproj
+++ b/WinBackupper/WinBackupper.vbproj
@@ -23,8 +23,8 @@
     <UpdatePeriodically>false</UpdatePeriodically>
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>10</ApplicationRevision>
-    <ApplicationVersion>0.0.0.%2a</ApplicationVersion>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>0.0.1.0</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <PublishWizardCompleted>true</PublishWizardCompleted>
     <BootstrapperEnabled>true</BootstrapperEnabled>

--- a/WinBackupper/home.Designer.vb
+++ b/WinBackupper/home.Designer.vb
@@ -102,10 +102,11 @@ Partial Class home
         '
         Me.l_version.AutoSize = True
         Me.l_version.BackColor = System.Drawing.Color.Transparent
+        Me.l_version.Font = New System.Drawing.Font("Microsoft Sans Serif", 10.0!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
         Me.l_version.ForeColor = System.Drawing.SystemColors.ButtonFace
-        Me.l_version.Location = New System.Drawing.Point(365, 310)
+        Me.l_version.Location = New System.Drawing.Point(342, 308)
         Me.l_version.Name = "l_version"
-        Me.l_version.Size = New System.Drawing.Size(77, 13)
+        Me.l_version.Size = New System.Drawing.Size(100, 17)
         Me.l_version.TabIndex = 11
         Me.l_version.Text = "Version: x.x.x.x"
         '

--- a/WinBackupper/home.vb
+++ b/WinBackupper/home.vb
@@ -18,6 +18,7 @@ Public Class home
     Public silent As Boolean = False
     Public Logfilename_Prefix As String = "BackupLog_" 'only use filename - no / allowed!
     Public LogfileFolder = "/Logs/" 'enter / %dirname / ! Slashes are Needed in front and at the end of this string!
+    Public Settings_Directory As String = "\Settings\"
 
 #End Region
 
@@ -101,9 +102,9 @@ Public Class home
             bw_versionControll.RunWorkerAsync() ' Start BW to write Version into XML File, see #Workers
 
             ' Check if there is a "default.xml" File
-            If Not Dir(getexedir() & "\default.xml") = "" Then
+            If Not Dir(getexedir() & Settings_Directory & "default.xml") = "" Then
                 ' Read XML File to load defaults
-                Dim xmlReader2 As XmlReader = New XmlTextReader(getexedir() & "\default.xml")
+                Dim xmlReader2 As XmlReader = New XmlTextReader(getexedir() & Settings_Directory & "default.xml")
                 ' Loop through XML File
                 While (xmlReader2.Read())
                     Dim type = xmlReader2.NodeType


### PR DESCRIPTION
Polishing for initial Release.
Also heavy changes to the update mechanics - it's now updating over
github - sadly it currently needs editing for each release - I'll try to
fix that for the next release.
Also I reverted the button to close the timetable form so that there is
only the "Apply times" button which writes the settings into the array
and closes thee form at the same time.
Of yourse I also edited the Version Numbers to match 0.0.1.0
I also moved the "default.xml" File into a "Settings" folder (Maybe we
want to have multiple setting files at some point?)And I fixxed some
Bugs I found when adding a directory which already get's backupped when
the user aborts. (The array would get corrupted because only the
sourcepath was entered and added to the arary, then it was aborted -
should be fixxed)
Have a look at the Release Now and test the Update...
I think U will like the whole package =).
(And if you jave bugs (Some HTML showing in the changelog) then try to log out anywhere from github... Not sure if that's the Case why it worked on my side.. maybe there is some Issue if you are logged in and the webrequest open the URL which otherwise downloads the file.... Just a thought...If so Im sure there is a workaround.
Nice work Dude!
